### PR TITLE
Updated the start script for v12.1.1 which no longer requires gulp.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,5 +2,6 @@
 
 set -eu pipefail
 
-node ./node_modules/gulp/bin/gulp generate-assets \
-  && node listen-on-port.js
+# node ./node_modules/gulp/bin/gulp generate-assets && node listen-on-port.js
+
+npm run build && npm run serve


### PR DESCRIPTION
Based on GDS prototype kit v12.1.1 - which does not use gulp, so the start script needs to be updated.