### PR TITLE
SAA-187 switching to latest ingress controller v1.2 as required by cloud platform.

### DIFF
--- a/kubernetes-deploy-main.tpl
+++ b/kubernetes-deploy-main.tpl
@@ -48,10 +48,10 @@ kind: Ingress
 metadata:
   name: prototype-ingress-${BRANCH}
   annotations:
-    kubernetes.io/ingress.class: nginx
     external-dns.alpha.kubernetes.io/set-identifier: prototype-ingress-${BRANCH}-${KUBE_NAMESPACE}-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
+  ingressClassName: default OR modsec
   tls:
   - hosts:
     - ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
See instructions [here](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.html#switch-ingress-to-the-new-nginx-ingress-controller-v1-2)

Given this is a proto no need to do it in stages.